### PR TITLE
feat: add new compress lz4

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -128,8 +128,8 @@ jobs:
           echo "Changed encoders: $changed_encoders_json"
           echo "Changed compress: $changed_compress_json"
 
-  # Lint main package if main/core files changed
-  lint-main:
+  # Test main package if main/core files changed
+  test-main:
     if: github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.main-changed == 'true'
     runs-on: ubuntu-latest
     needs: detect-changes
@@ -152,8 +152,8 @@ jobs:
           working-directory: .
           args: --timeout=5m ./...
 
-  # Lint changed encoder modules only (detected via .encoder files or workflow_call input)
-  lint-encoders:
+  # test changed encoder modules only (detected via .encoder files or workflow_call input)
+  test-encoders:
     if: github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.encoders-changed == 'true' && needs.detect-changes.outputs.changed-encoders != '[]'
     runs-on: ubuntu-latest
     needs: detect-changes
@@ -177,8 +177,8 @@ jobs:
           working-directory: ${{ matrix.encoder }}
           args: --timeout=5m --config ../.golangci.yml ./...
 
-  # Lint changed compress modules only (detected via .compress files or workflow_call input)
-  lint-compress:
+  # test changed compress modules only (detected via .compress files or workflow_call input)
+  test-compress:
     if: github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.compress-changed == 'true' && needs.detect-changes.outputs.changed-compress != '[]'
     runs-on: ubuntu-latest
     needs: detect-changes
@@ -202,11 +202,11 @@ jobs:
           working-directory: compress/${{ matrix.compress }}
           args: --timeout=5m --config ../../.golangci.yml ./...
 
-  # Generate lint summary for PR
-  lint-summary:
+  # Generate test summary for PR
+  test-summary:
     if: github.actor != 'dependabot[bot]' && always()
     runs-on: ubuntu-latest
-    needs: [detect-changes, lint-main, lint-encoders, lint-compress]
+    needs: [detect-changes, test-main, test-encoders, test-compress]
     steps:
       - name: 🔍 Generate lint summary
         run: |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Pluggable encoders for KiviGo. This small Go module provides a simple `Encoder` 
 go get github.com/kivigo/encoders/<encoder_name>
 ```
 
+## Included encoders
+
+- [`encoders/json`](https://pkg.go.dev/github.com/kivigo/encoders/json) — JSON encoder using `encoding/json` *(**Dependency-free**, default)*
+- [`encoders/yaml`](https://pkg.go.dev/github.com/kivigo/encoders/yaml) — YAML encoder using [`github.com/goccy/go-yaml`](https://github.com/goccy/go-yaml)
+- [`encoders/encrypt`](https://pkg.go.dev/github.com/kivigo/encoders/encrypt) — Encrypt encoder using [:heartbeat: `github.com/azrod/cryptio`](https://github.com/azrod/cryptio). Wrapper to encrypt/decrypt data using any other encoder (e.g. JSON + encryption)
+- [`encoders/compress`](https://pkg.go.dev/github.com/kivigo/encoders/compress) — Compression wrapper using various algorithms (LZ4, Gzip, custom). Each compression algorithm is released separately to keep dependencies minimal. Wrapper to compress/decompress data using any other encoder (e.g. JSON + compression or JSON + compression + encryption). You can write your own compression algorithm by implementing the [`model.Compressor`](https://pkg.go.dev/github.com/kivigo/encoders@main/model#Compressor) interface.
+  - [`encoders/compress/gzip`](https://pkg.go.dev/github.com/kivigo/encoders/compress/gzip) — Gzip compression using `compress/gzip` *(**Dependency-free**)*
+
 ## Encoder interface
 
 Implementations must satisfy a small interface used by the KiviGo client:
@@ -88,12 +96,6 @@ func example() error {
 }
 ```
 
-## Included encoders
-
-- `encoders/json` — JSON encoder using `encoding/json` *(**Dependency-free**, default)*
-- `encoders/yaml` — YAML encoder using [`github.com/goccy/go-yaml`](https://github.com/goccy/go-yaml)
-- `encoders/encrypt` — Wrapper to encrypt/decrypt data using any other encoder (e.g. JSON + encryption)
-
 ## Writing a custom encoder
 
 Create a type that implements `Encoder` and pass it to the client via `kivigo.Option{Encoder: myEncoder}`. Keep operations context-aware and error-returning.
@@ -114,4 +116,4 @@ go test ./...
 
 ## License
 
-MIT — see the root repository LICENSE file.
+Mozilla Public License v2.0. See [LICENSE](LICENSE) for details.

--- a/compress/lz4/.compress
+++ b/compress/lz4/.compress
@@ -1,0 +1,1 @@
+// This file is used to mark the directory as an compress module in the CI workflows.

--- a/compress/lz4/doc.go
+++ b/compress/lz4/doc.go
@@ -1,0 +1,6 @@
+// Package lz4 provides a Compressor implementation using the LZ4 compression algorithm.
+//
+// This package defines the Lz4Compressor type, which implements methods to compress and decompress
+// data using the github.com/pierrec/lz4/v4 library. It is suitable for fast compression and decompression
+// scenarios, such as database storage or network transmission.
+package lz4

--- a/compress/lz4/go.mod
+++ b/compress/lz4/go.mod
@@ -1,0 +1,8 @@
+module github.com/kivigo/encoders/compress/lz4
+
+go 1.24.0
+
+require (
+	github.com/kivigo/encoders v0.0.0-20250922203640-2b78b8576f98
+	github.com/pierrec/lz4/v4 v4.1.22
+)

--- a/compress/lz4/go.sum
+++ b/compress/lz4/go.sum
@@ -1,0 +1,4 @@
+github.com/kivigo/encoders v0.0.0-20250922203640-2b78b8576f98 h1:/F6NU0PBpifaYTLogjDAiiYl7wa8jB01Egoidk9q6HQ=
+github.com/kivigo/encoders v0.0.0-20250922203640-2b78b8576f98/go.mod h1:M6PxAe+gg0i37W42ofzCy3Lgwmie6MiKfkBtYnkkbns=
+github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
+github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=

--- a/compress/lz4/lz4.go
+++ b/compress/lz4/lz4.go
@@ -1,0 +1,43 @@
+package lz4
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/kivigo/encoders/model"
+	"github.com/pierrec/lz4/v4"
+)
+
+var _ model.Compressor = (*compressor)(nil)
+
+func New() model.Compressor {
+	return compressor{}
+}
+
+// compressor provides methods to compress and decompress data using the lz4 algorithm.
+type compressor struct{}
+
+// Compress compresses the input data using lz4 and returns the compressed bytes.
+func (compressor) Compress(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	w := lz4.NewWriter(&buf)
+	_, err := w.Write(data)
+	if err != nil {
+		w.Close()
+		return nil, err
+	}
+	err = w.Close()
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Decompress decompresses lz4-compressed data and returns the original bytes.
+func (compressor) Decompress(data []byte) ([]byte, error) {
+	r := lz4.NewReader(bytes.NewReader(data))
+	return io.ReadAll(r)
+}
+
+// Name returns the name of the compressor ("lz4").
+func (compressor) Name() string { return "lz4" }

--- a/compress/lz4/lz4_test.go
+++ b/compress/lz4/lz4_test.go
@@ -1,0 +1,45 @@
+package lz4
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestLz4Compressor_CompressAndDecompress(t *testing.T) {
+	comp := New()
+	original := []byte("hello world, this is a test")
+
+	// Test compression
+	compressed, err := comp.Compress(original)
+	if err != nil {
+		t.Fatalf("Compress failed: %v", err)
+	}
+	if bytes.Equal(compressed, original) {
+		t.Error("Compressed data should differ from original")
+	}
+
+	// Test decompression
+	decompressed, err := comp.Decompress(compressed)
+	if err != nil {
+		t.Fatalf("Decompress failed: %v", err)
+	}
+	if !bytes.Equal(decompressed, original) {
+		t.Errorf("Decompressed data mismatch: got %q, want %q", decompressed, original)
+	}
+}
+
+func TestLz4Compressor_Decompress_InvalidData(t *testing.T) {
+	comp := New()
+	invalid := []byte("not an lz4 stream")
+	_, err := comp.Decompress(invalid)
+	if err == nil {
+		t.Error("Expected error when decompressing invalid data, got nil")
+	}
+}
+
+func TestLz4Compressor_Name(t *testing.T) {
+	comp := New()
+	if comp.Name() != "lz4" {
+		t.Errorf("Name() = %q, want %q", comp.Name(), "lz4")
+	}
+}

--- a/testdata/go.mod
+++ b/testdata/go.mod
@@ -1,0 +1,14 @@
+module github.com/kivigo/encoders/testdata
+
+go 1.25.1
+
+replace github.com/kivigo/encoders/encrypt => ../encrypt
+
+require github.com/kivigo/encoders/encrypt v0.0.0-00010101000000-000000000000
+
+require (
+	github.com/azrod/cryptio v1.0.0 // indirect
+	github.com/kivigo/encoders v0.0.0-20250914204157-1fac3f1828ac // indirect
+	golang.org/x/crypto v0.42.0 // indirect
+	golang.org/x/sys v0.36.0 // indirect
+)

--- a/testdata/go.sum
+++ b/testdata/go.sum
@@ -1,0 +1,8 @@
+github.com/azrod/cryptio v1.0.0 h1:AoiYcXTdbJ/faUqvU5JH92H4rRF2Q0WNUkuvBDQKaW0=
+github.com/azrod/cryptio v1.0.0/go.mod h1:NzTMtYtrWyHkS9GbU3lJvwJ8bDDhUMaEgWGXSuUreYg=
+github.com/kivigo/encoders v0.0.0-20250914204157-1fac3f1828ac h1:CPhbt7FacwEpxMC1FZza4skaaCWaZrMo8esUjAU0jI0=
+github.com/kivigo/encoders v0.0.0-20250914204157-1fac3f1828ac/go.mod h1:M6PxAe+gg0i37W42ofzCy3Lgwmie6MiKfkBtYnkkbns=
+golang.org/x/crypto v0.42.0 h1:chiH31gIWm57EkTXpwnqf8qeuMUi0yekh6mT2AvFlqI=
+golang.org/x/crypto v0.42.0/go.mod h1:4+rDnOTJhQCx2q7/j6rAN5XDw8kPjeaXEUR2eL94ix8=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/testdata/main.go
+++ b/testdata/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/azrod/cryptio"
+	"github.com/kivigo/encoders/encrypt"
+)
+
+// Simple JSON encoder
+type jsonEncoder struct{}
+
+func (j *jsonEncoder) Encode(ctx context.Context, value any) ([]byte, error) {
+	return json.Marshal(value)
+}
+func (j *jsonEncoder) Decode(ctx context.Context, data []byte, value any) error {
+	return json.Unmarshal(data, value)
+}
+
+// Utility function to compress with gzip
+func compressGzip(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, err := w.Write(data)
+	if err != nil {
+		return nil, err
+	}
+	w.Close()
+	return buf.Bytes(), nil
+}
+
+// Utility function to decompress with gzip
+func decompressGzip(data []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return io.ReadAll(r)
+}
+
+type BigStruct struct {
+	Name    string
+	Numbers []int
+	Text    string
+}
+
+func main() {
+	// Generate a large structure
+	big := BigStruct{
+		Name:    "Alice",
+		Numbers: make([]int, 10000),
+		Text:    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ",
+	}
+
+	fmt.Println("Large structure generation completed.")
+	for i := range big.Numbers {
+		big.Numbers[i] = i
+	}
+	fmt.Println("Numbers filling completed.")
+
+	base := &jsonEncoder{}
+	enc, err := encrypt.New("super-secret", base, cryptio.SecurityMedium, cryptio.ProfileBalanced)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+
+	// Encode raw JSON
+	jsonRaw, err := base.Encode(ctx, big)
+	if err != nil {
+		panic(err)
+	}
+
+	// Encode + encrypt
+	encrypted, err := enc.Encode(ctx, big)
+	if err != nil {
+		panic(err)
+	}
+
+	// Gzip compression on raw JSON
+	jsonGz, err := compressGzip(jsonRaw)
+	if err != nil {
+		panic(err)
+	}
+
+	// Gzip compression on encrypted data
+	encryptedGz, err := compressGzip(encrypted)
+	if err != nil {
+		panic(err)
+	}
+
+	// Gzip compression on raw JSON then encryption
+	jsonGzEncrypted, err := enc.Encode(ctx, jsonGz)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Raw JSON size                : %d bytes\n", len(jsonRaw))
+	fmt.Printf("Compressed JSON size         : %d bytes\n", len(jsonGz))
+	fmt.Printf("Encrypted size               : %d bytes\n", len(encrypted))
+	fmt.Printf("Encrypted compressed size    : %d bytes\n", len(encryptedGz))
+	fmt.Printf("Compressed JSON encrypted size: %d bytes\n", len(jsonGzEncrypted))
+}


### PR DESCRIPTION
This pull request introduces a new LZ4 compression module for the project and updates documentation and CI workflows to support it. The most significant changes are the addition of the `compress/lz4` package, improvements to the README, and updates to the GitHub Actions workflow to replace linting jobs with testing jobs.

### Compression Module Addition
* Added a new `compress/lz4` package implementing the `model.Compressor` interface using the `github.com/pierrec/lz4/v4` library, including implementation, documentation, and tests. [[1]](diffhunk://#diff-1fea8972ae19a310ffc3cc1f22117b3c52183d659b61cca8de86d96467fd30d4R1-R43) [[2]](diffhunk://#diff-e9fb5cf2c68711ff518aa2e1965b7d26513500b8a5e979b168285ac764efb4dfR1-R6) [[3]](diffhunk://#diff-ecdb1a1b63fc7d84fcead5c5a037f8fe49c24461bda7143fdc9ebf15d01e61feR1-R45) [[4]](diffhunk://#diff-cff127437342049ee3e5e52ec46f8ef9fa3495756ecc7c82acb2753a9c561f8bR1-R8) [[5]](diffhunk://#diff-7f0d495dfcec82bf0cd7a120934e228bfb137ab2b5a314ed21fe7accd513bc81R1)

### CI Workflow Updates
* Updated `.github/workflows/go-test.yml` to replace lint jobs with test jobs for main, encoder, and compress modules, and updated summary generation to reflect testing instead of linting. [[1]](diffhunk://#diff-cb63f6037602c7aa1591d3dca2a9c1870ef95ac59f67aaa90dd9cd1163e20898L131-R132) [[2]](diffhunk://#diff-cb63f6037602c7aa1591d3dca2a9c1870ef95ac59f67aaa90dd9cd1163e20898L155-R156) [[3]](diffhunk://#diff-cb63f6037602c7aa1591d3dca2a9c1870ef95ac59f67aaa90dd9cd1163e20898L180-R181) [[4]](diffhunk://#diff-cb63f6037602c7aa1591d3dca2a9c1870ef95ac59f67aaa90dd9cd1163e20898L205-R209)

### Documentation Improvements
* Enhanced the `README.md` to provide a detailed list of included encoders and their dependencies, and updated the license section to Mozilla Public License v2.0. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-L96) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L117-R119)

### Test Data and Examples
* Added a new `testdata` module with a sample `main.go` demonstrating usage of JSON encoding, encryption, and gzip compression, and updated its dependencies in `go.mod`. [[1]](diffhunk://#diff-ab0a9016f393090fd368106fb3175db84f9bbf2a59b7017f449d3ac8675b78deR1-R14) [[2]](diffhunk://#diff-45caba1bd3eed70e558b858cbd1a1eaf1e29f455b215f51d680a89a6494c01eeR1-R110)